### PR TITLE
feat : fees estimations per order in client's invoicing page

### DIFF
--- a/src/locales/lang/en/data.ts
+++ b/src/locales/lang/en/data.ts
@@ -143,6 +143,7 @@ export default {
     effectiveDate: "Effective Date",
     erpStatus: "ERP Status",
     estimatedFeesForSelectedOrders: "Estimated fees for selected orders",
+    estimatedFees: "Estimated Fees",
     export: "Export",
     feeName: "Fee Name",
     finalAmount: "Final Amount",

--- a/src/locales/lang/zh-CN/data.ts
+++ b/src/locales/lang/zh-CN/data.ts
@@ -144,6 +144,7 @@ export default {
     effectiveDate: "生效日期",
     erpStatus: "ERP中状态",
     estimatedFeesForSelectedOrders: "当前已选择订单预计费用",
+    estimatedFees: "预计费用",
     export: "导出",
     feeName: "收费名称",
     finalAmount: "最终金额",

--- a/src/views/business/client/client.api.ts
+++ b/src/views/business/client/client.api.ts
@@ -24,4 +24,5 @@ export enum Api {
   cancelInvoice = '/invoice/cancelInvoice',
   uploadPaymentProofAndNotify = '/transaction/uploadPaymentProofAndNotify',
   findEarliestInvoiceYear = '/invoice/findEarliestInvoiceYear',
+  getOrderEstimations = '/shippingInvoice/completeFeesEstimationPerOrder',
 }

--- a/src/views/business/client/invoicing/Invoicing.vue
+++ b/src/views/business/client/invoicing/Invoicing.vue
@@ -165,6 +165,17 @@
             {{ text === 0 ? t("common.no") : t("common.yes") }}
           </Tag>
         </template>
+        <template #orderEstimation="{ record, text }">
+          <!-- TODO gérer les commandes avec erreurs -->
+          <div>
+            <div v-if="record?.shippingEstimation !== undefined">
+              <span class="text-xs">{{ t('data.invoice.shippingFee') }}:</span> <span class="font-semibold color-blue-500">{{ record?.shippingEstimation.toFixed(2) }}</span>
+            </div>
+            <div v-if="record?.purchaseEstimation !== undefined">
+              <span class="text-xs">{{ t('data.invoice.purchaseFee') }}:</span> <span class="font-semibold color-emerald-500">{{ record?.purchaseEstimation.toFixed(2) }}</span>
+            </div>
+          </div>
+        </template>
         <template #customFilterDropdown="{ setSelectedKeys, selectedKeys, confirm, clearFilters, column }">
           <div class="p-2 flex flex-col items-center justify-between w-48 min-h-20 mb-1 gap-4">
             <div class=" w-full flex flex-no-wrap gap-1">
@@ -658,7 +669,7 @@ async function syncSkus() {
     console.error(e);
   });
 }
-function loadOrders(arg?:number) {
+async function loadOrders(arg?:number) {
   if(arg === 1) {
     ipagination.value.current = 1;
     clearSelectedRowKeys();
@@ -674,8 +685,8 @@ function loadOrders(arg?:number) {
   makeCompleteDisabled.value = true;
   makeCompleteLoading.value = false;
   setLoading(true);
-  defHttp.get({url : Api.getOrderStatusByShop, params})
-    .then(res => {
+  await defHttp.get({url : Api.getOrderStatusByShop, params})
+    .then(async (res) => {
       orderList.value = res.records;
       total.value = res.total;
       page.value = res.current;
@@ -685,6 +696,8 @@ function loadOrders(arg?:number) {
         pageSize: pageSize.value,
         total: total.value,
       });
+      const orderIds = orderList.value.map(order => order.id);
+      await loadOrderEstimations({orderIds, clientID: client.value!.id});
     })
     .catch(e => {
       console.error(e);
@@ -692,6 +705,25 @@ function loadOrders(arg?:number) {
     .finally(() => {
       setLoading(false)
     });
+}
+async function loadOrderEstimations(params: {orderIds: string[], clientID: string}) {
+  await defHttp.get({url: Api.getOrderEstimations, params})
+    .then(res => {
+      const estimations = res.reduce((acc, estimation) => {
+        acc[estimation.orderId] = estimation
+        return acc
+      }, {})
+      orderList.value = orderList.value.map(order => {
+        if(estimations.hasOwnProperty(order.id)) {
+          order.shippingEstimation = estimations[order.id].shippingEstimation;
+          order.purchaseEstimation = estimations[order.id].purchaseEstimation || 0;
+        } else {
+          order.shippingEstimation = 0;
+          order.purchaseEstimation = 0;
+        }
+        return order;
+      });
+    })
 }
 function showPaginationTotal(total: number, range: [number, number]) {
   return range[0] + '-' + range[1] + ' / ' + total;

--- a/src/views/business/client/invoicing/data.tsx
+++ b/src/views/business/client/invoicing/data.tsx
@@ -79,7 +79,21 @@ export function getColumns(): BasicColumn[] {
       dataIndex: 'hasDesyncedSku',
       slots: {customRender: 'hasDesyncedSku'},
       helpMessage: t('data.tips.desyncTips')
-    }
+    },
+    {
+      title: t('data.invoice.estimatedFees'),
+      align: 'center',
+      fixed: 'right',
+      dataIndex: 'shippingEstimation',
+      slots: { customRender: 'orderEstimation' },
+    },
+    {
+      title: "Purchase Estimation",
+      align: 'center',
+      fixed: 'right',
+      dataIndex: 'purchaseEstimation',
+      defaultHidden: true,
+    },
   ];
 }
 export const pocColumns: BasicColumn[] = [


### PR DESCRIPTION
feat : estimation per order in client's page

TODO : do something maybe for order's with errors, right now it only shows 0 as fee it's not possible to calculate fees